### PR TITLE
fix: deprecation warnings from next intl

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opendocs-web",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -40,7 +40,7 @@
     "mdx-bundler": "^10.0.2",
     "next": "14.2.5",
     "next-contentlayer2": "^0.5.0",
-    "next-intl": "^3.17.2",
+    "next-intl": "^3.26.3",
     "next-themes": "^0.3.0",
     "normalize-path": "^3.0.0",
     "react": "^18.3.1",
@@ -52,19 +52,18 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@babel/core": "^7.24.9",
     "@opendocs/eslint-config": "workspace:*",
     "@opendocs/typescript-config": "workspace:*",
-    "typescript": "^5",
     "@types/node": "^20",
+    "@types/normalize-path": "^3.0.2",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "eslint": "8.57.0",
-    "eslint-config-next": "14.2.5",
-    "@babel/core": "^7.24.9",
-    "@types/normalize-path": "^3.0.2",
     "autoprefixer": "^10.4.19",
     "concurrently": "^8.2.2",
     "esbuild": "0.23.0",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
     "mdast-util-toc": "^7.1.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.39",
@@ -78,6 +77,7 @@
     "remark-gfm": "^4.0.0",
     "shiki": "^1.11.0",
     "tailwindcss": "^3.4.6",
+    "typescript": "^5",
     "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.0.0"
   }

--- a/apps/web/src/app/[locale]/blog/[[...slug]]/page.tsx
+++ b/apps/web/src/app/[locale]/blog/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale, getTranslations } from 'next-intl/server'
+import { setRequestLocale, getTranslations } from 'next-intl/server'
 import { Suspense } from 'react'
 
 import type { LocaleOptions } from '@/lib/opendocs/types/i18n'
@@ -36,7 +36,7 @@ export async function generateMetadata({
 }: BlogPageProps): Promise<Metadata> {
   const locale = params.locale || defaultLocale
 
-  unstable_setRequestLocale(locale)
+  setRequestLocale(locale)
 
   const [t, blogPost] = await Promise.all([
     getTranslations('site'),
@@ -153,7 +153,7 @@ export async function generateStaticParams(): Promise<
 export default async function BlogPage({ params }: BlogPageProps) {
   const locale = params.locale || defaultLocale
 
-  unstable_setRequestLocale(locale)
+  setRequestLocale(locale)
 
   const t = await getTranslations()
   const blogPost = await getBlogFromParams({ params })

--- a/apps/web/src/app/[locale]/blog/layout.tsx
+++ b/apps/web/src/app/[locale]/blog/layout.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from 'next-intl/server'
+import { setRequestLocale } from 'next-intl/server'
 
 import type { LocaleOptions } from '@/lib/opendocs/types/i18n'
 
@@ -15,7 +15,7 @@ export default async function BlogLayout({
   children,
   params,
 }: BlogLayoutProps) {
-  unstable_setRequestLocale(params.locale)
+  setRequestLocale(params.locale)
 
   return (
     <div className="container mx-auto max-w-container px-4 pt-6 sm:px-6 lg:px-8">

--- a/apps/web/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server'
+import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { allDocs } from 'contentlayer/generated'
 
 import type { LocaleOptions } from '@/lib/opendocs/types/i18n'
@@ -28,7 +28,7 @@ export async function generateMetadata({
 }: DocPageProps): Promise<Metadata> {
   const locale = params.locale
 
-  unstable_setRequestLocale(locale || defaultLocale)
+  setRequestLocale(locale || defaultLocale)
 
   const doc = await getDocFromParams({ params })
 
@@ -84,7 +84,7 @@ export async function generateStaticParams(): Promise<
 }
 
 export default async function DocPage({ params }: DocPageProps) {
-  unstable_setRequestLocale(params.locale || defaultLocale)
+  setRequestLocale(params.locale || defaultLocale)
 
   const doc = await getDocFromParams({ params })
   const t = await getTranslations('docs')

--- a/apps/web/src/app/[locale]/docs/layout.tsx
+++ b/apps/web/src/app/[locale]/docs/layout.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from 'next-intl/server'
+import { setRequestLocale } from 'next-intl/server'
 
 import { getServerDocsConfig } from '@/lib/opendocs/utils/get-server-docs-config'
 import { DocsSidebarNav } from '@/components/docs/sidebar-nav'
@@ -19,7 +19,7 @@ export default async function DocsLayout({
   children,
   params,
 }: DocsLayoutProps) {
-  unstable_setRequestLocale(params.locale)
+  setRequestLocale(params.locale)
 
   const docsConfig = await getServerDocsConfig({ locale: params.locale })
 

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from 'next-intl/server'
+import { setRequestLocale } from 'next-intl/server'
 
 import type { LocaleOptions } from '@/lib/opendocs/types/i18n'
 import type { Metadata, Viewport } from 'next'
@@ -13,6 +13,7 @@ import { defaultLocale } from '@/config/i18n'
 import { siteConfig } from '@/config/site'
 import { fontSans } from '@/lib/fonts'
 import { cn } from '@/lib/utils'
+import { NextIntlClientProvider } from 'next-intl'
 
 interface AppLayoutProps {
   children: React.ReactNode
@@ -26,7 +27,7 @@ export async function generateMetadata({
 }: {
   params: { locale: LocaleOptions }
 }): Promise<Metadata> {
-  unstable_setRequestLocale(params.locale || defaultLocale)
+  setRequestLocale(params.locale || defaultLocale)
 
   return {
     title: {
@@ -113,7 +114,7 @@ export const viewport: Viewport = {
 }
 
 export default function RootLayout({ children, params }: AppLayoutProps) {
-  unstable_setRequestLocale(params.locale)
+  setRequestLocale(params.locale)
 
   return (
     <html lang={params.locale || defaultLocale} suppressHydrationWarning>
@@ -127,24 +128,29 @@ export default function RootLayout({ children, params }: AppLayoutProps) {
           fontSans.variable
         )}
       >
-        <ThemeProvider
-          enableSystem
-          attribute="class"
-          defaultTheme="dark"
-          disableTransitionOnChange
+        <NextIntlClientProvider
+          locale={params.locale || defaultLocale}
+          messages={{}}
         >
-          <div>
-            <div className="relative z-10 flex min-h-screen flex-col">
-              <SiteHeader />
+          <ThemeProvider
+            enableSystem
+            attribute="class"
+            defaultTheme="dark"
+            disableTransitionOnChange
+          >
+            <div>
+              <div className="relative z-10 flex min-h-screen flex-col">
+                <SiteHeader />
 
-              <main className="flex-1">{children}</main>
+                <main className="flex-1">{children}</main>
 
-              <SiteFooter />
+                <SiteFooter />
+              </div>
+
+              <div className="fixed left-0 top-0 size-full bg-gradient-to-b from-[#a277ff] via-transparent to-transparent opacity-10" />
             </div>
-
-            <div className="fixed left-0 top-0 size-full bg-gradient-to-b from-[#a277ff] via-transparent to-transparent opacity-10" />
-          </div>
-        </ThemeProvider>
+          </ThemeProvider>
+        </NextIntlClientProvider>
       </body>
     </html>
   )

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server'
+import { getTranslations, setRequestLocale } from 'next-intl/server'
 import dynamic from 'next/dynamic'
 
 import { TextGenerateEffect } from '@/components/ui/text-generate-effect'
@@ -32,7 +32,7 @@ export default async function IndexPage({
 }: {
   params: { locale: LocaleOptions }
 }) {
-  unstable_setRequestLocale(params.locale)
+  setRequestLocale(params.locale)
 
   const t = await getTranslations()
 

--- a/apps/web/src/config/site.ts
+++ b/apps/web/src/config/site.ts
@@ -22,7 +22,7 @@ export const siteConfig = {
   },
 
   app: {
-    latestVersion: '3.0.5',
+    latestVersion: '3.0.6',
   },
 
   author: {

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -1,16 +1,24 @@
 import { getRequestConfig } from 'next-intl/server'
 import deepmerge from 'deepmerge'
 
+import type { LocaleOptions } from '@/lib/opendocs/types/i18n'
 import type { AbstractIntlMessages } from 'next-intl'
 
-import { defaultLocale } from '@/config/i18n'
+import { locales } from '@/config/i18n'
+import { routing } from '@/navigation'
 
-export default getRequestConfig(async ({ locale }) => {
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale = await requestLocale
+
   const fallbackMessages: AbstractIntlMessages = await import(
-    `@/i18n/locales/${defaultLocale}.json`
+    `@/i18n/locales/${routing.defaultLocale}.json`
   )
 
   let messagesFromCurrentLocale: AbstractIntlMessages = {}
+
+  if (!locale || !locales.includes(locale as LocaleOptions)) {
+    locale = routing.defaultLocale
+  }
 
   try {
     messagesFromCurrentLocale = await import(`@/i18n/locales/${locale}.json`)
@@ -18,5 +26,5 @@ export default getRequestConfig(async ({ locale }) => {
 
   const messages = deepmerge(fallbackMessages, messagesFromCurrentLocale)
 
-  return { messages }
+  return { messages, locale }
 })

--- a/apps/web/src/lib/opendocs/middleware.ts
+++ b/apps/web/src/lib/opendocs/middleware.ts
@@ -1,17 +1,10 @@
 import { NextResponse, type NextRequest } from 'next/server'
-
 import nextIntlMiddleware from 'next-intl/middleware'
 
-import { defaultLocale, locales } from '@/config/i18n'
+import { routing } from './navigation'
 
 const intlMiddleware = (request: NextRequest) =>
-  Promise.resolve(
-    nextIntlMiddleware({
-      locales,
-      defaultLocale,
-      localePrefix: 'as-needed',
-    })(request)
-  )
+  Promise.resolve(nextIntlMiddleware(routing)(request))
 
 export default async function middleware(request: NextRequest) {
   request.headers.set('x-pathname', request.nextUrl.pathname)

--- a/apps/web/src/lib/opendocs/navigation.ts
+++ b/apps/web/src/lib/opendocs/navigation.ts
@@ -1,6 +1,13 @@
-import { createSharedPathnamesNavigation } from 'next-intl/navigation'
+import { createNavigation } from 'next-intl/navigation'
+import { defineRouting } from 'next-intl/routing'
 
-import { locales } from '@/config/i18n'
+import { locales, defaultLocale } from '@/config/i18n'
+
+export const routing = defineRouting({
+  locales,
+  defaultLocale,
+  localePrefix: 'as-needed',
+})
 
 export const { Link, redirect, usePathname, useRouter } =
-  createSharedPathnamesNavigation({ locales, localePrefix: 'as-needed' })
+  createNavigation(routing)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         specifier: ^0.5.0
         version: 0.5.3(acorn@8.14.0)(contentlayer2@0.5.3(acorn@8.14.0)(esbuild@0.23.0)(markdown-wasm@1.2.0))(esbuild@0.23.0)(markdown-wasm@1.2.0)(next@14.2.5(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
-        specifier: ^3.17.2
+        specifier: ^3.26.3
         version: 3.26.3(next@14.2.5(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
@@ -6574,7 +6574,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.7.3))(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.7.3)
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.0))
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.7.3))(eslint@8.57.0)
@@ -7313,7 +7313,7 @@ snapshots:
       eslint-plugin-turbo: 2.3.4(eslint@8.57.0)(turbo@2.3.4)
       turbo: 2.3.4
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.0)):
     dependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.7.3))(eslint@8.57.0)
 


### PR DESCRIPTION
- upgrades next-intl to v3.26.3
- fixes [deprecation warnings from next intl](https://next-intl.dev/blog/next-intl-3-22)